### PR TITLE
Keep alive issue

### DIFF
--- a/http-web-server/src/main/java/org/dochi/http/processor/Http11Processor.java
+++ b/http-web-server/src/main/java/org/dochi/http/processor/Http11Processor.java
@@ -26,36 +26,9 @@ public class Http11Processor extends AbstractHttpProcessor {
         );
     }
 
-    // keep-alive timeout over -> socketTimeoutException -> send Connection: close 헤더 추가해서 응답하지 못함
-    // keep-alive count >= max keep-alive count -> send Connection: close 헤더 추가해서 응답
-
-    // keep-alive max 값에 도달했지만, close 헤더 필드 값을 설정하지않고 서버에서 소켓을 닫아서, TCP 스택에서 socket read error 발생
-
-    // 1. Client -> GET -> Server
-    // 2. Server -> FIN, ACK -> Client 서버에서 클라에게 얘기도 없이 소켓 연결을 끊는다고 알림
-    // 3. Server -> RST, ASK -> Client
-    // 4. Client -> ASK -> Server
-    // 5. Server -> RST -> Client
-    // 6. Client -> TCP 3 way handshake -> Server
-
-    // 1. 서버에서 클라에게 얘기도 없이(Connect:close 헤더 설정), 소켓 close()를 호출해서 FIN, ACK 패킷 전송
-    // 2. 클라에서 FIN, ACK 패킷을 받기전, GET 요청을 함
-    // 3. 서버는 GET 요청을 받아서 연결을 강제 종료하였다고 RST, ACK 패킷을 전송 (정상적인 TCP 4-way handshake로 정상 종료한게 아님)
-    // 4. 클라는 FIN, ACK 패킷을 받아서 알겠다고 ACK 패킷을 서버에게 전송
-    // 5. 서버에서 ACK 패킷을 받아서 연결을 강제 종료했다고 RST 패킷을 클라에게 전송
-    // 6. 클라는 서버와 다시 TCP 연결 시도
-
-
-    // The packet arrives at a TCP connection that was previously established, but the local application already closed its socket or exited and the OS closed the socket.
-    // The client closes the socket cuz request max count to server, although the server send a packet reach processing request max count.
-    // If keep using Connection: keep-alive, the client doesn't close the socket.
-    // Server can close the socket anytime, so keep-alive timeout and max value just reference thing.
-    // But server should notice will close the socket to the client.
-
     public boolean shouldKeepAlive(SocketWrapper socketWrapper) {
         return isRequestKeepAlive() && isSeverKeepAlive(socketWrapper);
     }
-
 
     private boolean shouldNext(SocketWrapper socketWrapper) {
         boolean isKeepAlive = shouldKeepAlive(socketWrapper);
@@ -82,41 +55,37 @@ public class Http11Processor extends AbstractHttpProcessor {
         return request.getHttpVersion().equals(HttpVersion.HTTP_1_0) && (connectionValue != null && connectionValue.equals("keep-alive"));
     }
 
-    // UPGRADING 요청이면, HTTP API 실행하지 않고 소켓 상태 반환
     protected SocketState service(SocketWrapper socketWrapper, HttpApiMapper httpApiMapper) {
         SocketState state = OPEN;
         int processCount = 0;
         try {
-            // 멀티스레딩 환경에서 동시에 객체에 접근안할지라도 공유 자원의 수정이 CPU 캐시에만 반영되고 메인 메모리에 반영되지 않을수 있기때문에
-            // 메모리 가시성을 확보하기 위해서는 객체 사용전에 초기화를 하는 것이 volatile 변수를 사용하는 것보다 성능이 좋다.
-            // volatile 변수는 hardware level 에서 메모리의 가시성을 위해서 CPU에 수정된 값을 메인 메모리에 즉시 반영한다. 따라서 성능의 오버헤드가 발생한다.
             recycle();
             while (state == OPEN) {
                 if (!request.isPrepareHeader()) {
-                    request.recycle();
+                    request.recycle(); // memory visibility
+                    // Recycling object's sharing resource cannot match the main memory with cpu cache in multithreading environment.
+                    // I choose recycling object initialization cuz volatile variable for memory visibility has overhead.
                     state = CLOSED;
                     break;
-                }
-                if (isUpgradeRequest(socketWrapper)) {
-                    // 현재는 서버가 업그레이드 제안을 무시하고 원본 요청에 대해 HTTP/1.1로 처리하도록한다.
-                    // 향후 http2 프로토콜로 통신하는 기능을 추가할때 수월하도록 구조만 잡는다.
-                    // upgrade token(Upgrade, HTTP2-Settings)만 복제 (Request 전체 복제 하면 낭비)
-
+                } else if (isUpgradeRequest(socketWrapper)) {
+                    // Current ignore HTTP/1.1 upgrade request, processing as HTTP/1.1 (Later support HTTP/2.0)
                     state = UPGRADING;
-                    // upgradeToken 업데이트: upgradeToken = getHeader(Upgrade) & getHeader(HTTP2-Settings);
-
-                    // 이후, HTTP/1.1로 101 응답 -> preface 요청 -> HTTP/2.0으로 응답
-                    // 1. HTTP/1.1로 101 응답을 DefaultHttpApiHandler에 로직 작성
-                    // 2. process 메서드 호출 객체가 UPGRADING 상태를 받아서 Http2Processor로 변경
+                    // 1. upgradeToken(); // upgradeToken = getHeader(Upgrade) & getHeader(HTTP2-Settings);
+                    // 2. sendUpgrade(); // HTTP/1.1 response 101 status
+                    // 3. break;
+                    // After client preface request -> response as HTTP/2.0 using Http2Processor
                 } else if (!shouldNext(socketWrapper)) {
                     state = CLOSED;
                 }
                 httpApiMapper.getHttpApiHandler(request.getPath()).service(request, response);
-                response.getOutputStream().flush();
-                recycle(); // request.recycle(): multipart/form-data 파일을 일시적으로 저장하도록해서 요청 처리 이후 파일 바로 삭제하기 위해 recycle()
-                // response.flush();
-                // 그런데 멀티파트에서 파일을 꼭 요청 처리 이후에 삭제해야할까?
-                // 멀티파트에서 파일은 용량이 크기때문에 가급적 바로 삭제하는 것이 좋다.
+
+                // response.flush()
+                // Response object provides OutputStream object to developer, so it need flush() after processing HTTP API
+                // flush() has system call cost, it needs to remove inefficient action.
+                // 1. Rapping flush method by custom OutputStream.
+                // 2. The custom OutputStream declares boolean-isFlushed variable.
+                // 3. If call rapped flush method, According to isFlushed value(true/false), flush() to be called or not.
+                recycle();
                 processCount++;
             }
         } catch (Exception e) {
@@ -128,58 +97,12 @@ public class Http11Processor extends AbstractHttpProcessor {
         return state;
     }
 
-    /*
-    GET / HTTP/1.1
-    Host: localhost:8080
-    Connection: Upgrade, HTTP2-Settings
-    Upgrade: h2c
-    HTTP2-Settings: AAMAAABkAAQAoAAAAAIAAAAA
-    */
-
-    // h2c: 비암호화된 HTTP/2의 방식
-    // HTTP2-Settings: HTTP/2 설정 정보: 최대 스트림 개수, 초기 윈도우 크기 등
-
-    // h2c(HTTP/2 Cleartext) 업그레이드 과정
-    // 1. HTTP/1.1로 Upgrade: h2c 헤더로 HTTP/2.0 업그레이드 제안
-    // 2. 서버에서 HTTP/2.0 업그레이드를 수락했다고 101 Switching Protocol 응답
-    // 3. 파싱한 요청 데이터(Upgrade, HTTP2-Settings)가 저장된 객체를 리스너나 콜백 패턴으로 넘겨서 HTTP/2.0 프로토콜 설정
-    // 4. 101 응답을 준 후 지속 연결 유지한채로 Http2Processor 객체 생성 (연결이 끊기면 무효화되어 HTTP/2.0으로 요청 진행 안함)
-    // 5. 서버는 HTTP/2 연결 프리페이스(connection preface) 수신 대기
-    // 6. 클라는 101 응답에 대해 서버의 HTTP/2.0 전환을 확인하기 위한 매직 문자열("PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n")과 SETTINGS 프레임 전송
-    // 7. 서버도 자신의 SETTINGS 프레임으로
-    // 8. 이후 클라이언트와 서버는 HTTP/2 프로토콜을 사용하여 요청
-
-    // 현재는 서버가 업그레이드 제안을 무시하고 원본 요청에 대해 HTTP/1.1로 처리해놓는다.
-    // 향후 http2 프로토콜로 통신하는 기능을 추가할때 수월하도록 구조만 잡는다.
-    private boolean isUpgradeRequest(SocketWrapper socketWrapper) throws CloneNotSupportedException {
-//        if (!request.getHeader(RequestHeaders.UPGRADE).isEmpty()) {
-//            새롭게 설정한 로직 (SocketWrapper가 SocketState를 저장하지 않고 메서드로 반환)
-//            1. ProtocolHandler가 SocketState.Upgrading을 반환받는다.
-//            2. ProtocolHandler가 UpgradeToken getUpgradeToken() 이나 Request getUpgradeRequest() 호출
-//            3. ProtocolHandler의 AbstractProcessor createProcessor(http2) 호출하여, Request이나 UpgradeToken를 주입해서 Http2Processor를 생성
-//
-//            기존의 설정한 로직 (SocketWrapper가 SocketState를 저장)
-//            socketWrapper.markUpgrading();
-//            Request upgradeRequest = this.request.getParsedRequest().clone();
-
-            // 1. HttpRequestProcessor로부터 파싱된 요청 데이터(request.getParsedRequest())를 가져와서 clone (101 응답보내면 저장된 요청 데이터는 refresh된다.)
-            // 2. upgrade 전용 응답 (HTTP/1.1) -> sendUpgrade()
-            // 3. Listener나 call back 패턴으로 ProtocolHandler에게 clone한 헤더 객체를 넘긴다. (얕은 복사를 해도 Request 객체는 반복문을 탈출해서 데이터 변환없음)
-            // 4. ProtocolHandler는 기존의 사용하던 소켓 입출력스트림으로 Http2Processor 객체를 생성하고 process 메서드를 실행시킨다.
-            // 5. clone한 헤더 객체로 원본 응답을 수행한다. (?)
-//
-//            return true;
-//        }
-//        return false;
+    private boolean isUpgradeRequest(SocketWrapper socketWrapper) {
         return  request.getHeader(RequestHeaders.UPGRADE) != null;
     }
 
 //    private void sendUpgrade() {
-//        try {
-//            response.sendUpgrade();
-//        } catch (Exception e) {
-//            processException(e);
-//        }
+//
 //    }
 }
 

--- a/http-web-server/src/main/java/org/dochi/http/processor/Http11Processor.java
+++ b/http-web-server/src/main/java/org/dochi/http/processor/Http11Processor.java
@@ -1,15 +1,20 @@
 package org.dochi.http.processor;
 
+import org.dochi.http.api.HttpApiMapper;
+import org.dochi.http.request.data.RequestHeaders;
 import org.dochi.http.request.processor.Http11RequestProcessor;
 import org.dochi.http.request.data.HttpVersion;
 import org.dochi.http.request.stream.Http11RequestStream;
 import org.dochi.http.response.Http11ResponseProcessor;
 import org.dochi.webserver.config.HttpConfig;
+import org.dochi.webserver.socket.SocketState;
 import org.dochi.webserver.socket.SocketWrapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.*;
+
+import static org.dochi.webserver.socket.SocketState.*;
 
 public class Http11Processor extends AbstractHttpProcessor {
     private static final Logger log = LoggerFactory.getLogger(Http11Processor.class);
@@ -21,34 +26,107 @@ public class Http11Processor extends AbstractHttpProcessor {
         );
     }
 
-    @Override
-    protected boolean shouldNextRequest(SocketWrapper socketWrapper) {
-        return shouldKeepAlive(socketWrapper.getKeepAliveTimeout(), socketWrapper.getMaxKeepAliveRequests())
-                && socketWrapper.incrementKeepAliveCount() < socketWrapper.getMaxKeepAliveRequests();
+    // keep-alive timeout over -> socketTimeoutException -> send Connection: close 헤더 추가해서 응답하지 못함
+    // keep-alive count >= max keep-alive count -> send Connection: close 헤더 추가해서 응답
+
+    // keep-alive max 값에 도달했지만, close 헤더 필드 값을 설정하지않고 서버에서 소켓을 닫아서, TCP 스택에서 socket read error 발생
+
+    // 1. Client -> GET -> Server
+    // 2. Server -> FIN, ACK -> Client 서버에서 클라에게 얘기도 없이 소켓 연결을 끊는다고 알림
+    // 3. Server -> RST, ASK -> Client
+    // 4. Client -> ASK -> Server
+    // 5. Server -> RST -> Client
+    // 6. Client -> TCP 3 way handshake -> Server
+
+    // 1. 서버에서 클라에게 얘기도 없이(Connect:close 헤더 설정), 소켓 close()를 호출해서 FIN, ACK 패킷 전송
+    // 2. 클라에서 FIN, ACK 패킷을 받기전, GET 요청을 함
+    // 3. 서버는 GET 요청을 받아서 연결을 강제 종료하였다고 RST, ACK 패킷을 전송 (정상적인 TCP 4-way handshake로 정상 종료한게 아님)
+    // 4. 클라는 FIN, ACK 패킷을 받아서 알겠다고 ACK 패킷을 서버에게 전송
+    // 5. 서버에서 ACK 패킷을 받아서 연결을 강제 종료했다고 RST 패킷을 클라에게 전송
+    // 6. 클라는 서버와 다시 TCP 연결 시도
+
+
+    // The packet arrives at a TCP connection that was previously established, but the local application already closed its socket or exited and the OS closed the socket.
+    // The client closes the socket cuz request max count to server, although the server send a packet reach processing request max count.
+    // If keep using Connection: keep-alive, the client doesn't close the socket.
+    // Server can close the socket anytime, so keep-alive timeout and max value just reference thing.
+    // But server should notice will close the socket to the client.
+
+    public boolean shouldKeepAlive(SocketWrapper socketWrapper) {
+        return isRequestKeepAlive() && isSeverKeepAlive(socketWrapper);
     }
 
-    private boolean shouldKeepAlive(int timeout, int maxRequests) {
-        boolean isKeepAlive = isKeepAlive();
+
+    private boolean shouldNext(SocketWrapper socketWrapper) {
+        boolean isKeepAlive = shouldKeepAlive(socketWrapper);
         response.addConnection(isKeepAlive);
         if (isKeepAlive) {
-            response.addKeepAlive(timeout, maxRequests);
+           response.addKeepAlive(socketWrapper.getKeepAliveTimeout(), socketWrapper.getMaxKeepAliveRequests());
         }
         return isKeepAlive;
     }
 
-    private boolean isKeepAlive() {
-        if (request.getHttpVersion().equals(HttpVersion.HTTP_1_1)) {
-            return !request.getConnection().equalsIgnoreCase("close");
-        }
-        return request.getHttpVersion().equals(HttpVersion.HTTP_1_0) && request.getConnection().equalsIgnoreCase("keep-alive");
+    private boolean isSeverKeepAlive(SocketWrapper socketWrapper) {
+        return !isReachedMax(socketWrapper.incrementKeepAliveCount(), socketWrapper.getMaxKeepAliveRequests());
     }
 
-    // http2 업그레이드
-    //    @Override
-//    protected boolean shouldContinue(SocketWrapper socketWrapper) throws Exception {
-//        // shouldNextRequest 메서드에 if (request.getConnection("Upgrade")) -> socketWrapper.setSocketState = UPGRADING -> break;
-//        return super.shouldContinue(socketWrapper) && !isUpgradeConnection(socketWrapper);
-//    }
+    private static boolean isReachedMax(int currentCount, int maxCount) {
+        return currentCount >= maxCount;
+    }
+
+    private boolean isRequestKeepAlive() {
+        String connectionValue = request.getConnection();
+        if (request.getHttpVersion().equals(HttpVersion.HTTP_1_1)) {
+            return !(connectionValue != null && connectionValue.equals("close"));
+        }
+        return request.getHttpVersion().equals(HttpVersion.HTTP_1_0) && (connectionValue != null && connectionValue.equals("keep-alive"));
+    }
+
+    // UPGRADING 요청이면, HTTP API 실행하지 않고 소켓 상태 반환
+    protected SocketState service(SocketWrapper socketWrapper, HttpApiMapper httpApiMapper) {
+        SocketState state = OPEN;
+        int processCount = 0;
+        try {
+            // 멀티스레딩 환경에서 동시에 객체에 접근안할지라도 공유 자원의 수정이 CPU 캐시에만 반영되고 메인 메모리에 반영되지 않을수 있기때문에
+            // 메모리 가시성을 확보하기 위해서는 객체 사용전에 초기화를 하는 것이 volatile 변수를 사용하는 것보다 성능이 좋다.
+            // volatile 변수는 hardware level 에서 메모리의 가시성을 위해서 CPU에 수정된 값을 메인 메모리에 즉시 반영한다. 따라서 성능의 오버헤드가 발생한다.
+            recycle();
+            while (state == OPEN) {
+                if (!request.isPrepareHeader()) {
+                    request.recycle();
+                    state = CLOSED;
+                    break;
+                }
+                if (isUpgradeRequest(socketWrapper)) {
+                    // 현재는 서버가 업그레이드 제안을 무시하고 원본 요청에 대해 HTTP/1.1로 처리하도록한다.
+                    // 향후 http2 프로토콜로 통신하는 기능을 추가할때 수월하도록 구조만 잡는다.
+                    // upgrade token(Upgrade, HTTP2-Settings)만 복제 (Request 전체 복제 하면 낭비)
+
+                    state = UPGRADING;
+                    // upgradeToken 업데이트: upgradeToken = getHeader(Upgrade) & getHeader(HTTP2-Settings);
+
+                    // 이후, HTTP/1.1로 101 응답 -> preface 요청 -> HTTP/2.0으로 응답
+                    // 1. HTTP/1.1로 101 응답을 DefaultHttpApiHandler에 로직 작성
+                    // 2. process 메서드 호출 객체가 UPGRADING 상태를 받아서 Http2Processor로 변경
+                } else if (!shouldNext(socketWrapper)) {
+                    state = CLOSED;
+                }
+                httpApiMapper.getHttpApiHandler(request.getPath()).service(request, response);
+                response.getOutputStream().flush();
+                recycle(); // request.recycle(): multipart/form-data 파일을 일시적으로 저장하도록해서 요청 처리 이후 파일 바로 삭제하기 위해 recycle()
+                // response.flush();
+                // 그런데 멀티파트에서 파일을 꼭 요청 처리 이후에 삭제해야할까?
+                // 멀티파트에서 파일은 용량이 크기때문에 가급적 바로 삭제하는 것이 좋다.
+                processCount++;
+            }
+        } catch (Exception e) {
+            processException(e);
+            safeRecycle();
+            state = CLOSED;
+        }
+        log.debug("Processed keep-alive requests count: {}", processCount);
+        return state;
+    }
 
     /*
     GET / HTTP/1.1
@@ -73,21 +151,28 @@ public class Http11Processor extends AbstractHttpProcessor {
 
     // 현재는 서버가 업그레이드 제안을 무시하고 원본 요청에 대해 HTTP/1.1로 처리해놓는다.
     // 향후 http2 프로토콜로 통신하는 기능을 추가할때 수월하도록 구조만 잡는다.
-//    private boolean isUpgradeConnection(SocketWrapper socketWrapper) throws CloneNotSupportedException {
+    private boolean isUpgradeRequest(SocketWrapper socketWrapper) throws CloneNotSupportedException {
 //        if (!request.getHeader(RequestHeaders.UPGRADE).isEmpty()) {
+//            새롭게 설정한 로직 (SocketWrapper가 SocketState를 저장하지 않고 메서드로 반환)
+//            1. ProtocolHandler가 SocketState.Upgrading을 반환받는다.
+//            2. ProtocolHandler가 UpgradeToken getUpgradeToken() 이나 Request getUpgradeRequest() 호출
+//            3. ProtocolHandler의 AbstractProcessor createProcessor(http2) 호출하여, Request이나 UpgradeToken를 주입해서 Http2Processor를 생성
+//
+//            기존의 설정한 로직 (SocketWrapper가 SocketState를 저장)
 //            socketWrapper.markUpgrading();
 //            Request upgradeRequest = this.request.getParsedRequest().clone();
-//
-//            // 1. HttpRequestProcessor로부터 파싱된 요청 데이터(request.getParsedRequest())를 가져와서 clone (101 응답보내면 저장된 요청 데이터는 refresh된다.)
-//            // 2. upgrade 전용 응답 (HTTP/1.1) -> sendUpgrade()
-//            // 3. Listener나 call back 패턴으로 ProtocolHandler에게 clone한 헤더 객체를 넘긴다. (얕은 복사를 해도 Request 객체는 반복문을 탈출해서 데이터 변환없음)
-//            // 4. ProtocolHandler는 기존의 사용하던 소켓 입출력스트림으로 Http2Processor 객체를 생성하고 process 메서드를 실행시킨다.
-//            // 5. clone한 헤더 객체로 원본 응답을 수행한다. (?)
+
+            // 1. HttpRequestProcessor로부터 파싱된 요청 데이터(request.getParsedRequest())를 가져와서 clone (101 응답보내면 저장된 요청 데이터는 refresh된다.)
+            // 2. upgrade 전용 응답 (HTTP/1.1) -> sendUpgrade()
+            // 3. Listener나 call back 패턴으로 ProtocolHandler에게 clone한 헤더 객체를 넘긴다. (얕은 복사를 해도 Request 객체는 반복문을 탈출해서 데이터 변환없음)
+            // 4. ProtocolHandler는 기존의 사용하던 소켓 입출력스트림으로 Http2Processor 객체를 생성하고 process 메서드를 실행시킨다.
+            // 5. clone한 헤더 객체로 원본 응답을 수행한다. (?)
 //
 //            return true;
 //        }
 //        return false;
-//    }
+        return  request.getHeader(RequestHeaders.UPGRADE) != null;
+    }
 
 //    private void sendUpgrade() {
 //        try {

--- a/http-web-server/src/main/java/org/dochi/http/processor/HttpProcessor.java
+++ b/http-web-server/src/main/java/org/dochi/http/processor/HttpProcessor.java
@@ -1,8 +1,9 @@
 package org.dochi.http.processor;
 
 import org.dochi.http.api.HttpApiMapper;
+import org.dochi.webserver.socket.SocketState;
 import org.dochi.webserver.socket.SocketWrapper;
 
 public interface HttpProcessor {
-    void process(SocketWrapper socketWrapper, HttpApiMapper httpApiMapper);
+    SocketState process(SocketWrapper socketWrapper, HttpApiMapper httpApiMapper);
 }

--- a/http-web-server/src/main/java/org/dochi/http/response/Http11ResponseProcessor.java
+++ b/http-web-server/src/main/java/org/dochi/http/response/Http11ResponseProcessor.java
@@ -91,14 +91,9 @@ public class Http11ResponseProcessor implements HttpResponseProcessor {
         send(status, null, null);
     }
 
-    //
     public void send(HttpStatus status, byte[] body, String contentType) throws IOException {
         addDefaultHeader(status, getContentLength(body), contentType);
         writeMessage(body);
-//        writeStatusLine();
-//        writeHeaders();
-//        writeBody(body);
-
     }
 
     private static int getContentLength(byte[] body) {
@@ -150,6 +145,7 @@ public class Http11ResponseProcessor implements HttpResponseProcessor {
         int bytesRead;
         final byte[] buffer = new byte[8192];
         try(InputStream in = splitFileResource.getInputStream()) {
+            // byte[]를 생성하는 대신 BufferedOutputStream 자식 클래스를 작성해서 buf 넘긴다.
             while ((bytesRead = in.read(buffer)) != -1) {
                 try {
                     bos.write(buffer, 0, bytesRead);
@@ -179,7 +175,7 @@ public class Http11ResponseProcessor implements HttpResponseProcessor {
         if (body != null) {
             bos.write(body, 0, body.length);
         }
-        bos.flush(); // 스트림 버퍼의 데이터를 OS의 네트워크 스택인 TCP(socket) 버퍼에 즉시 전달 보장 (DataOutputStream은 8바이트의 버퍼 하나 존재)
+        bos.flush(); // 스트림 버퍼의 데이터를 OS의 네트워크 스택인 TCP(socket) 버퍼에 즉시 전달 보장
     }
 
     public OutputStream getOutputStream() {

--- a/http-web-server/src/test/java/org/dochi/webserver/socket/SocketWrapperBaseTest.java
+++ b/http-web-server/src/test/java/org/dochi/webserver/socket/SocketWrapperBaseTest.java
@@ -1,90 +1,90 @@
-//package org.dochi.webserver.socket;
-//
-//import org.dochi.webserver.attribute.KeepAlive;
-//import org.junit.jupiter.api.Test;
-//
-//import org.junit.jupiter.api.*;
-//import java.io.*;
-//import java.net.*;
-//
-//import static org.junit.jupiter.api.Assertions.assertEquals;
-//
-//class SocketWrapperBaseTest {
-//    // BioEndpoint 내에 ServerSocket 객채 감춘다.
-//    // BioEndpoint extends AbstractEndpoint<U>
-//    // AbstractEndpoint 내에 Acceptor<U> acceptor, SocketWrapperBase<U> socketWrapper
-//    private static ServerSocket serverSocket;
-//    private SocketWrapperBase<Socket> socketWrapper;
-//
-//    // 테스트 클래스 내의 모든 테스트가 실행되기 전에 딱 한 번 ServerSocket.accept() 메서드를 실행
-//    // NIO 확장성을 위해서는 서버 소켓의 적용이 필요함
-//    // 클라이언트가 요청 메세지를 보내면 스레드 실행이 종료됨
-//    @BeforeAll
-//    static void startServer() throws IOException {
-//        System.out.println("Starting server...");
-//        serverSocket = new ServerSocket(0); // 사용 가능한 포트 자동 할당
-//
-//        new Thread(() -> {
-//            while (!serverSocket.isClosed()) { // 여러 클라이언트 요청 처리 가능하도록 변경
-//                try (Socket socket = serverSocket.accept();
-//                     OutputStream out = socket.getOutputStream()) {
-//                    // write boolean true;
-//                    // flush();
-//                    // 클라 read -> assertTrue(socketWrapper.read());
-//                    out.write(new byte[] { 10, 20, 30, 40, 50 });
-//                    out.flush();
-//                } catch (IOException e) {
-//                    if (!serverSocket.isClosed()) {
-//                        throw new RuntimeException(e);
-//                    }
-//                }
-//            }
-//        }).start();
-//    }
-//
-//    // 테스트의 무결성을 위해 각 메서드마다 새로운 클라 연결 생성
-//    @BeforeEach
-//    void setUp() throws IOException {
-//        // 클라이언트 소켓을 서버에 연결
-//        socketWrapper = new BioSocketWrapper(new KeepAlive());
-//        socketWrapper.setConnectedSocket(new Socket("localhost", serverSocket.getLocalPort()));
-//    }
-//
-//    @Test
-//    void testRead1() throws IOException {
-//        byte[] buffer = new byte[5];
-//        int bytesRead = socketWrapper.read(buffer, 1, 3);
-//
-//        assertEquals(3, bytesRead);
-//        assertEquals(0, buffer[0]);
-//        assertEquals(10, buffer[1]);
-//        assertEquals(20, buffer[2]);
-//        assertEquals(30, buffer[3]);
-//        assertEquals(0, buffer[4]);
-//    }
-//
-//    @Test
-//    void testRead2() throws IOException {
-//        byte[] buffer = new byte[5];
-//        int bytesRead = socketWrapper.read(buffer, 1, 3);
-//
-//        assertEquals(3, bytesRead);
-//        assertEquals(0, buffer[0]);
-//        assertEquals(10, buffer[1]);
-//        assertEquals(20, buffer[2]);
-//        assertEquals(30, buffer[3]);
-//        assertEquals(0, buffer[4]);
-//    }
-//
-//    // 테스트의 무결성을 위해 각 메서드마다 새로운 클라 연결 종료
-//    @AfterEach
-//    void tearDown() throws IOException {
-//        socketWrapper.close();
-//    }
-//
-//    @AfterAll
-//    static void stopServer() throws IOException {
-//        serverSocket.close();
-//        System.out.println("Stop server...");
-//    }
-//}
+package org.dochi.webserver.socket;
+
+import org.dochi.webserver.attribute.KeepAlive;
+import org.junit.jupiter.api.Test;
+
+import org.junit.jupiter.api.*;
+import java.io.*;
+import java.net.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SocketWrapperBaseTest {
+    // BioEndpoint 내에 ServerSocket 객채 감춘다.
+    // BioEndpoint extends AbstractEndpoint<U>
+    // AbstractEndpoint 내에 Acceptor<U> acceptor, SocketWrapperBase<U> socketWrapper
+    private static ServerSocket serverSocket;
+    private SocketWrapperBase<Socket> socketWrapper;
+
+    // 테스트 클래스 내의 모든 테스트가 실행되기 전에 딱 한 번 ServerSocket.accept() 메서드를 실행
+    // NIO 확장성을 위해서는 서버 소켓의 적용이 필요함
+    // 클라이언트가 요청 메세지를 보내면 스레드 실행이 종료됨
+    @BeforeAll
+    static void startServer() throws IOException {
+        System.out.println("Starting server...");
+        serverSocket = new ServerSocket(0); // 사용 가능한 포트 자동 할당
+
+        new Thread(() -> {
+            while (!serverSocket.isClosed()) { // 여러 클라이언트 요청 처리 가능하도록 변경
+                try (Socket socket = serverSocket.accept();
+                     OutputStream out = socket.getOutputStream()) {
+                    // write boolean true;
+                    // flush();
+                    // 클라 read -> assertTrue(socketWrapper.read());
+                    out.write(new byte[] { 10, 20, 30, 40, 50 });
+                    out.flush();
+                } catch (IOException e) {
+                    if (!serverSocket.isClosed()) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            }
+        }).start();
+    }
+
+    // 테스트의 무결성을 위해 각 메서드마다 새로운 클라 연결 생성
+    @BeforeEach
+    void setUp() throws IOException {
+        // 클라이언트 소켓을 서버에 연결
+        socketWrapper = new BioSocketWrapper(new KeepAlive());
+        socketWrapper.setConnectedSocket(new Socket("localhost", serverSocket.getLocalPort()));
+    }
+
+    @Test
+    void testRead1() throws IOException {
+        byte[] buffer = new byte[5];
+        int bytesRead = socketWrapper.read(buffer, 1, 3);
+
+        assertEquals(3, bytesRead);
+        assertEquals(0, buffer[0]);
+        assertEquals(10, buffer[1]);
+        assertEquals(20, buffer[2]);
+        assertEquals(30, buffer[3]);
+        assertEquals(0, buffer[4]);
+    }
+
+    @Test
+    void testRead2() throws IOException {
+        byte[] buffer = new byte[5];
+        int bytesRead = socketWrapper.read(buffer, 1, 3);
+
+        assertEquals(3, bytesRead);
+        assertEquals(0, buffer[0]);
+        assertEquals(10, buffer[1]);
+        assertEquals(20, buffer[2]);
+        assertEquals(30, buffer[3]);
+        assertEquals(0, buffer[4]);
+    }
+
+    // 테스트의 무결성을 위해 각 메서드마다 새로운 클라 연결 종료
+    @AfterEach
+    void tearDown() throws IOException {
+        socketWrapper.close();
+    }
+
+    @AfterAll
+    static void stopServer() throws IOException {
+        serverSocket.close();
+        System.out.println("Stop server...");
+    }
+}


### PR DESCRIPTION
# Keep-Alive Issue: Client Socket Read Error Occurrence

## Finding the cause of the problem

To resolve the **client socket read error** that occurred under low server load conditions, I needed to identify the issue in my web server implementation.

#### 1. Could a Short Keep-Alive Timeout Be the Cause?

I suspected that **frequent TCP connections due to a short keep-alive timeout** might have caused socket read errors. To verify this, I increased the keep-alive timeout from **1000ms to 20000ms**.

**Test Conditions:**

- **Socket receive buffer:** 408300 bytes
- **Keep-Alive timeout:** 20000ms, **max request:** 100

```bash
wrk -t4 -c10 -d30s http://localhost:8080/index.html
```

```bash
Running 30s test @ http://localhost:8080/index.html
  4 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     3.08ms   20.01ms 329.60ms   97.49%
    Req/Sec     7.31k     1.99k    9.79k    84.88%
  863827 requests in 30.02s, 615.39MB read
  Socket errors: connect 0, read 8634, write 0, timeout 0
Requests/sec:  28778.04
Transfer/sec:     20.50MB
```

After increasing the Keep-Alive timeout to **20 seconds**, the socket read error/request ratio decreased to **1%**, but errors were still occurring under relatively low load conditions.

**Test Result: Socket read error/request ratio ~1%**

#### 2. Could the Socket Receive Buffer Be Too Small?

I suspected that **if the application read speed was too slow relative to the socket receive buffer size, it might cause socket read errors**. To verify this, I increased the buffer size from **~399KB to 1MB**.

**Test Conditions:**

- **Socket receive buffer:** 1,024,000 bytes
- **Keep-Alive timeout:** 20000ms, **max request:** 100

```bash
wrk -t4 -c10 -d30s http://localhost:8080/index.html
```

```bash
Running 30s test @ http://localhost:8080/index.html
  4 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    17.31ms   71.52ms 657.70ms   94.18%
    Req/Sec     6.12k     2.39k     9.48k    73.29%
  680662 requests in 30.04s, 484.90MB read
  Socket errors: connect 0, read 6802, write 0, timeout 0
Requests/sec:  22655.53
Transfer/sec:     16.14MB
```

Even after increasing the buffer size, the **socket read error/request ratio remained at 1%**, similar to the previous test. This led me to suspect a **fundamental implementation issue rather than a performance issue**.

**Test Result: Socket read error/request ratio ~1%**

#### 3. Load-Free Test to Identify Web Server Implementation Issues

I ran a **low-load test** with a **single thread and single connection for 1 second**, but the **socket read error/request ratio still remained at ~1%**.

**This proved that the issue was not due to server performance but an implementation problem.**  
However, since **it was a client socket read error, the issue was not immediately apparent in the web server code.**

```bash
wrk -t1 -c1 -d1s http://localhost:8080/index.html
```

```bash
Running 1s test @ http://localhost:8080/index.html
  1 threads and 1 connections
  Socket errors: connect 0, read 49, write 0, timeout 0
Requests/sec:   4518.46
Transfer/sec:     3.15MB
```

**Test Result: Socket read error/request ratio ~1%**

---
## Problem Analysis

#### TCP Packet Capture

Since the issue was not clearly visible in application logs or code, I used WireShark to capture packets in order to analyze the problem in the HTTP and TCP stack. 
![](https://i.imgur.com/1BWlrKE.png)

**From the captured packets, it is immediately noticeable that an RST packet error occurred. Although I was initially unfamiliar with RST packets, I inferred their purpose from their name. An RST packet is sent by the receiving application to indicate that the socket connection has been reset. This means that the TCP connection, which was in the `ESTABLISHED` state, has been reset.**

#### Scenario Analysis 

In the given scenario, the server sent a packet to the client indicating that the connection had been reset. Now, let's analyze the sequence of events.

1. Client -> `GET` -> Server: The client sends a `GET` request before receiving the `FIN` packet from the server.
2. Server -> `FIN` -> Client: The server calls `Socket.close()`, sending a `FIN` packet.  
3. Server -> `RST` -> Client: The server receives the client's `GET` request and sends an `RST` packet, indicating that the connection has been reset (TCP 4-way handshake is not properly completed).  
4. Client -> `ACK` -> Server: The client receives the `FIN` packet from the server and sends an `ACK` packet in response.  
5. Server -> `RST` -> Client: Upon receiving the `ACK` packet, the server sends another `RST` packet to the client, indicating that the connection has been reset.
6. Client -> TCP 3-way handshake -> Server: The client attempts to establish a new TCP connection with the server.

**In this scenario, the issue arises at step `3`, when the server sends an RST packet. This suggests that the cause of the problem lies in the preceding captured packets.**  

**Step `1` represents a normal `GET` request sent by WRK. This means that the issue originates at step `2`, where the `FIN` packet is sent. The `FIN` packet is transmitted when a socket is closed, which, in my Java-based web server, occurs when `Socket.close()` is called.**

**This strongly suggests that the server closed the socket abruptly without following the proper TCP connection termination process, leaving the client unaware of the disconnection.**

---
## Problem Resolution

#### Identifying the Issue in Code

**Since the server likely called `Socket.close()` without notifying the client, resulting in a `FIN` packet being sent**, I examined the relevant code responsible for closing the web server's socket. However, the code did not immediately reveal any issues.

#### Identifying the Issue in Logs

Instead, by reviewing the web server's request handling logs, I noticed that each connection was processing up to the Keep-Alive max value of 100 requests before establishing a new connection.
```bash
[pool-2-thread-5] DEBUG o.d.w.socket.SocketTaskHandler - Running socket task connected to a client [Client: /127.0.0.1, Port: 58431]
[pool-2-thread-5] DEBUG o.d.webserver.socket.SocketWrapper - Start connection timeout: 20000 [Client IP: /127.0.0.1]
[pool-2-thread-9] DEBUG o.d.http.processor.Http11Processor - Processed keep-alive requests count: 100

[pool-2-thread-9] DEBUG o.d.w.socket.SocketTaskHandler - Running socket task connected to a client [Client: /127.0.0.1, Port: 58432]
[pool-1-thread-1] INFO  o.dochi.webserver.socket.Connector - Accepted new client connection [Client IP: /127.0.0.1, Port: 58521]
[pool-2-thread-9] DEBUG o.d.webserver.socket.SocketWrapper - Start connection timeout: 20000 [Client IP: /127.0.0.1]
[pool-1-thread-1] INFO  o.dochi.webserver.socket.Connector - Accepted new client connection [Client IP: /127.0.0.1, Port: 58522]
[pool-2-thread-1] DEBUG o.d.http.processor.Http11Processor - Processed keep-alive requests count: 100
````

The log indicates that the Keep-Alive max request limit was set to 100, meaning that the socket was closed (`close()`) after processing 100 requests within a single connection.

The probability of encountering a socket read error on the client (WRK) was around 1%. Given this, I suspected that an error was occurring on the request immediately following the 100th request. I then examined the HTTP response message sent when Keep-Alive reached its max value, along with the subsequent handling logic.

Upon inspecting the code that sets the response headers when Keep-Alive reaches its max value, I noticed that the `Connection` header was incorrectly set to `keep-alive` instead of `close`.

#### Verifying the Fix

After modifying the code to set the `Connection` header to `close` when the Keep-Alive max value was reached, the issue was resolved.

```bash
wrk -t4 -c10 -d30s http://localhost:8080/index.html

Running 30s test @ http://localhost:8080/index.html
  4 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     1.14ms   11.02ms 243.60ms   98.84%
    Req/Sec    15.73k     3.75k   19.27k    89.26%
  1866650 requests in 30.01s, 1.30GB read
Requests/sec:  62193.97
Transfer/sec:     44.28MB
```

As shown in the test results above, after the fix, no more socket read errors occurred as long as the web server was not overloaded. The issue stemmed from the fact that the server did not explicitly indicate that it was closing the socket in the response message, leading the client to unknowingly send a request after the server had already attempted to close the connection.

**This experience reinforced the importance of logs in identifying problem areas more efficiently than code analysis alone.**

